### PR TITLE
Add call to #calculate_reorder_date on start

### DIFF
--- a/app/models/spree/subscription.rb
+++ b/app/models/spree/subscription.rb
@@ -123,6 +123,7 @@ class Spree::Subscription < ActiveRecord::Base
   def set_checkout_requirements
     order = self.line_item.order
     # DD: TODO: set quantity?
+    calculate_reorder_date!
     update_attributes(
       :billing_address_id => order.bill_address_id,
       :shipping_address_id => order.ship_address_id,


### PR DESCRIPTION
This commit adds a call to `#calculate_reorder_date` when transitioning a subscription to `start` that sets the reorder date for new subscriptions. Without this call, new subscriptions never had a reorder date set.
