### PR TITLE
Updates to Subscription#index view page

### DIFF
--- a/app/controllers/spree/admin/subscriptions_controller.rb
+++ b/app/controllers/spree/admin/subscriptions_controller.rb
@@ -1,10 +1,17 @@
-class Spree::Admin::SubscriptionsController < Spree::Admin::ResourceController
+module Spree
+  module Admin
+    class SubscriptionsController < Spree::Admin::BaseController
 
-  def index
-    # DD: stolen from Spree::Admin::OrdersController
-    @search = Spree::Subscription.ransack(params[:q])
-    @subscriptions = @search.result.includes([:user]).
-      page(params[:page]).
-      per(params[:per_page] || Spree::Config[:orders_per_page])
+      def index
+        @search = Spree::Subscription.post_cart.ransack(params[:q])
+        @subscriptions = @search.result.includes([:user]).
+          page(params[:page]).
+          per(params[:per_page] || Spree::Config[:orders_per_page])
+      end
+
+      def edit
+
+      end
+    end
   end
 end

--- a/app/models/spree/subscription.rb
+++ b/app/models/spree/subscription.rb
@@ -20,6 +20,7 @@ class Spree::Subscription < ActiveRecord::Base
   has_many :reorders, :class_name => "Spree::Order"
 
   scope :active, where(:state => 'active')
+  scope :post_cart, where("state != ?", "cart")
 
   state_machine :state, :initial => 'cart' do
     event :suspend do

--- a/app/views/spree/admin/subscriptions/index.html.erb
+++ b/app/views/spree/admin/subscriptions/index.html.erb
@@ -41,7 +41,7 @@
           <span class="product-name"><%= sub.line_item.variant.name %></span><br/>
           <%= sub.line_item.variant.options_text %>
         </td>
-        <td class="subscription-user"><%= sub.user.id %></td>
+        <td class="subscription-user"><%= link_to(sub.user.email, :controller => "spree/admin/users", :action => "show", :id => sub.user.id) if sub.user %></td>
         <td class="subscription-price"><%= money sub.line_item.price %></td>
         <td class="subscription-interval"><%= sub.time_title %></td>
         <td class="subscription-reorder-date">


### PR DESCRIPTION
This pull request fixes the display of subscriptions for guest users, as it was calling id on nil before.

It also includes a new Subscription scope `post_cart` that filters out cart subscriptions for the `Subscription#index` view because they're not valid subscriptions yet. It updates the `SubscriptionsController#index` action to use the new scope.

And lastly, it updates the `SubscriptionsController` to use `BaseController` which includes authentication checks. Before this change you could view the subscription index without being logged in as an admin.
